### PR TITLE
add helm lint step to CI and fix chart

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,6 +9,15 @@ jobs:
       - run: yarn
       - run: yarn test
 
+  helmLint:
+    docker:
+      - image: web3f/ci-commons:v2.0.1
+    steps:
+      - checkout
+      - run:
+          command: |
+            helm lint ./charts/polkadot-watcher
+
   buildImage:
     docker:
       - image: web3f/ci-commons:v2.0.1
@@ -57,6 +66,10 @@ workflows:
           filters:
             tags:
               only: /.*/
+      - helmLint:
+          filters:
+            tags:
+              only: /.*/
       - buildImage:
           filters:
             tags:
@@ -68,6 +81,7 @@ workflows:
             tags:
               only: /.*/
           requires:
+            - helmLint
             - unitTest
       - publishImage:
           filters:

--- a/charts/polkadot-watcher/Chart.yaml
+++ b/charts/polkadot-watcher/Chart.yaml
@@ -1,3 +1,4 @@
 description: Polkadot Watcher
 name: polkadot-watcher
 version: v0.4.5
+apiVersion: v2


### PR DESCRIPTION
apiVersion field is now required in Chart.yaml. We need to add a helm lint step to all the CI pipelines.